### PR TITLE
Allow gitit2 to work as a proper subsite.

### DIFF
--- a/Network/Gitit2.hs
+++ b/Network/Gitit2.hs
@@ -59,7 +59,6 @@ import Control.Exception (throw, handle, try)
 import Text.Highlighting.Kate
 import Data.Time (getCurrentTime, addUTCTime)
 import Yesod.AtomFeed
-import Yesod.Default.Handlers (getFaviconR, getRobotsR)
 import Data.Yaml
 import System.Directory
 import System.Time (ClockTime (..), getClockTime)
@@ -229,8 +228,6 @@ mkYesodSub "Gitit" [ ClassP ''HasGitit [VarT $ mkName "master"]
 /_static StaticR Static getStatic
 /_index IndexBaseR GET
 /_index/*Page  IndexR GET
-/favicon.ico FaviconR GET
-/robots.txt RobotsR GET
 /_random RandomR GET
 /_raw/*Page RawR GET
 /_edit/*Page  EditR GET

--- a/gitit2.cabal
+++ b/gitit2.cabal
@@ -51,7 +51,6 @@ library
                  -- , yesod-platform                >= 1.1        && < 1.2
                  , yesod                         >= 1.1        && < 1.2
                  , yesod-static                  >= 1.1        && < 1.2
-                 , yesod-default                 >= 1.1        && < 1.2
                  , yesod-core                    >= 1.1        && < 1.2
                  , yesod-form                    >= 1.1        && < 1.2
                  , yesod-test                    >= 0.3        && < 0.4
@@ -97,6 +96,7 @@ executable gitit2
     hs-source-dirs: src
     build-depends: base                          >= 4          && < 5
                  , yesod                         >= 1.1        && < 1.2
+                 , yesod-default                 >= 1.1        && < 1.2
                  , yesod-static                  >= 1.1        && < 1.2
                  , filestore                     >= 0.5        && < 0.6
                  , containers                    >= 0.4        && < 0.5

--- a/src/gitit2.hs
+++ b/src/gitit2.hs
@@ -3,6 +3,7 @@
 import Network.Gitit2
 import Network.Socket hiding (Debug)
 import Yesod
+import Yesod.Default.Handlers (getFaviconR, getRobotsR)
 import Yesod.Static
 import Network.Wai.Handler.Warp
 import Data.FileStore
@@ -24,7 +25,10 @@ import Text.Pandoc.Definition
 
 data Master = Master { getGitit :: Gitit, maxUploadSize :: Int }
 mkYesod "Master" [parseRoutes|
-/ SubsiteR Gitit getGitit
+/gitit SubsiteR Gitit getGitit
+/   RootR GET
+/favicon.ico FaviconR GET
+/robots.txt RobotsR GET
 |]
 
 instance Yesod Master where
@@ -56,6 +60,11 @@ instance HasGitit Master where
   requireUser = return $ GititUser "Dummy" "dumb@dumber.org"
   makePage = makeDefaultPage
   getPlugins = return [samplePlugin]
+
+-- | A get request for / will redirect to the gitit subsite's home page.
+getRootR :: Handler RepHtml
+getRootR = do
+    redirect $ SubsiteR $ HomeR
 
 -- | Ready collection of common mime types. (Copied from
 -- Happstack.Server.HTTP.FileServe.)


### PR DESCRIPTION
This change allows gitit2 to work as a subsite with a Yesod scaffolded
application.

This change removes some routes from the subsite that would conflict
with routes that usually exist in a master site.

To do this in the sample application , I had to move the subsite out of
/ to a more specific directory, and then redirect / to gitit's subsite
default route.

There may be a better way of accomplishing this, but this seemed like
the obvious solution.
