### PR TITLE
Correct and simplify the logic introduced before to handle approot:

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1,5 +1,6 @@
-use_tls: false
-host: localhost
+# approot is the base path used for links in your application
+# it defaults to localhost (here http://localhost:3000)
+# approot: http://mydomain:myport
 port: 3000
 repository_path: wikidata
 repository_type: git

--- a/src/gitit2.hs
+++ b/src/gitit2.hs
@@ -74,13 +74,6 @@ instance Yesod Master where
   -- needed for BrowserId - can we set it form config or request?
   approot = ApprootMaster $ appRoot . settings
 
-  -- load resources from /static instead of approot (http://...),
-  -- convenient when serving under https reverse proxy
-  urlRenderOverride y (StaticR s) =
-    Just $ uncurry (joinPath y (staticRoot $ settings y)) $ renderRoute s
-
-  urlRenderOverride _ _ = Nothing
-
 instance YesodAuth Master where
   type AuthId Master = Text
   getAuthId = return . Just . credsIdent


### PR DESCRIPTION
 - Only the port is needed to run gitit2
 - The approot defaults to `http://locahost:port` but can be set to an
 arbitrary url (with a different or no port) from the settings file